### PR TITLE
Update TouchableLift.tsx

### DIFF
--- a/src/TouchableLift.tsx
+++ b/src/TouchableLift.tsx
@@ -1,9 +1,10 @@
 import { View, useAnimationState } from 'moti';
 import React from 'react';
-import { Pressable, PressableProps } from 'react-native';
+import { Pressable, PressableProps, ViewStyle } from 'react-native';
 
-interface Props extends PressableProps {
+interface Props extends Omit<PressableProps, 'style'> {
 	value?: number;
+	style?: ViewStyle
 }
 
 export default function TouchableLift(props: Props) {
@@ -27,7 +28,7 @@ export default function TouchableLift(props: Props) {
 	return (
 		<Pressable {...other} onPressIn={pressedIn} onPressOut={pressedOut}>
 			<View
-				{...style}
+				style={style}
 				state={animationState}
 				transition={{
 					type: 'timing',


### PR DESCRIPTION
- Fixed style prop not being passed directly
- Style type should be `ViewStyle`, since `Pressable`'s style also allows a function.

I recommend doing the same for the other files.